### PR TITLE
Return a third value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Provides a macroexpand-all function that calls the implementation specific equiv
 
 Supports: `abcl`, `allegro`, `ccl`, `clisp`, `cmucl`, `corman`, `lispworks`, `mkcl`, `sbcl`, `ecl` & `scl`
 
-If you the function from a supported implementation then the two return values are:
+If you the function from a supported implementation then the three return values are:
 - the expanded form
 - t
+- t, if the implementation specific equivalent accepts an environment
 
-If you the function from an usupported implementation then the two return values are:
+If you the function from an usupported implementation then the three return values are:
 - the original form
+- nil
 - nil
 
 ## Example

--- a/trivial-macroexpand-all.lisp
+++ b/trivial-macroexpand-all.lisp
@@ -2,58 +2,58 @@
 
 #+abcl
 (defun macroexpand-all (form &optional env)
-  (values (ext:macroexpand-all form env) t))
+  (values (ext:macroexpand-all form env) t t))
 
 #+allegro
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
   #+(and allegro-version>= (version>= 8 0))
-  (values (excl::walk-form form) t)
+  (values (excl::walk-form form) t nil)
   #-(and allegro-version>= (version>= 8 0))
-  (values (excl::walk form) t))
+  (values (excl::walk form) t nil))
 
 #+ccl
 (defun macroexpand-all (form &optional env)
-  (values (ccl:macroexpand-all form env) t))
+  (values (ccl:macroexpand-all form env) t t))
 
 #+clisp
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values (ext:expand-form form) t))
+  (values (ext:expand-form form) t nil))
 
 #+cmucl
 (defun macroexpand-all (form &optional env)
-  (values (walker:macroexpand-all form env) t))
+  (values (walker:macroexpand-all form env) t t))
 
 #+corman
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values (ccl:macroexpand-all form) t))
+  (values (ccl:macroexpand-all form) t nil))
 
 #+ecl
 (defun macroexpand-all (form &optional env)
-  (values (walker:macroexpand-all form env) t))
+  (values (walker:macroexpand-all form env) t t))
 
 #+lispworks
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values (walker:walk-form form) t))
+  (values (walker:walk-form form) t nil))
 
 #+mkcl
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values (walker:macroexpand-all form) t))
+  (values (walker:macroexpand-all form) t nil))
 
 #+sbcl
 (defun macroexpand-all (form &optional env)
-  (values (sb-cltl2:macroexpand-all form env) t))
+  (values (sb-cltl2:macroexpand-all form env) t t))
 
 #+scl
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values (macroexpand form) t))
+  (values (macroexpand form) t nil))
 
 #-(or abcl allegro ccl clisp cmucl corman ecl lispworks mkcl sbcl scl)
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
-  (values form nil))
+  (values form nil nil))


### PR DESCRIPTION
The idea here is to make it safe to use macroexpand-all within a macro, where you care about the environment. Now macroexpand-all returns three values, where the third value is T when the environment parameter is not ignored.