### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Provides a macroexpand-all function that calls the implementation specific equiv
 
 Supports: `abcl`, `allegro`, `ccl`, `clisp`, `cmucl`, `corman`, `lispworks`, `mkcl`, `sbcl`, `ecl` & `scl`
 
-If you the function from a supported implementation then the three return values are:
+If you use the function from a supported implementation then the three return values are:
 - the expanded form
 - t
 - t, if the implementation specific equivalent accepts an environment
 
-If you the function from an usupported implementation then the three return values are:
+If you use the function from an unsupported implementation then the three return values are:
 - the original form
 - nil
 - nil


### PR DESCRIPTION
if you the function -> if you *use* the function
usupported -> unsupported

Fixes #4