### PR TITLE
Consolidate MACROEXPAND-ALL for CMUCL and ECL

### DIFF
--- a/trivial-macroexpand-all.lisp
+++ b/trivial-macroexpand-all.lisp
@@ -21,7 +21,7 @@
   (declare (ignore env))
   (values (ext:expand-form form) t nil))
 
-#+cmucl
+#+(or cmucl ecl)
 (defun macroexpand-all (form &optional env)
   (values (walker:macroexpand-all form env) t t))
 
@@ -29,10 +29,6 @@
 (defun macroexpand-all (form &optional env)
   (declare (ignore env))
   (values (ccl:macroexpand-all form) t nil))
-
-#+ecl
-(defun macroexpand-all (form &optional env)
-  (values (walker:macroexpand-all form env) t t))
 
 #+lispworks
 (defun macroexpand-all (form &optional env)


### PR DESCRIPTION
The `MACROEXPAND-ALL` function for CMUCL and ECL are identical. Therefore they have been consolidated into one.